### PR TITLE
Riak2.0 driver changes, scalaz 7.1, scala 2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ import sbt._
 
 name := "scaliak"
 
-organization := "org.megam"
+organization := "com.stackmob"
 
 scalaVersion := "2.11.2"
 
@@ -25,7 +25,7 @@ scalacOptions := Seq(
   "-Yinline",
   "-Yclosure-elim",
   "-Ybackend:GenBCode",
-  "closurify:delegating", 
+  "closurify:delegating",
   "-language:implicitConversions",
   "-language:higherKinds",
   "-language:reflectiveCalls",
@@ -62,7 +62,7 @@ scalacOptions := Seq(
       "org.apache.commons" % "commons-pool2" % "2.2",
       "org.slf4j" % "slf4j-api" % "1.7.7",
       //"ch.qos.logback" % "logback-classic" % "1.1.2",
-      "org.specs2" % "specs2_2.11" % "2.4" % "test"
+      "org.specs2" % "specs2_2.11" % "2.4.1" % "test"
       )
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,9 @@ name := "scaliak"
 
 organization := "com.stackmob"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.10.4"
+
+crossScalaVersions := Seq("2.10.4", "2.11.2")
 
 scalacOptions := Seq(
   "-target:jvm-1.7",
@@ -21,11 +23,11 @@ scalacOptions := Seq(
   "-Xcheckinit",
   "-Xlint",
   "-Xverify",
-  "-Yconst-opt",
   "-Yinline",
   "-Yclosure-elim",
-  "-Ybackend:GenBCode",
-  "closurify:delegating",
+  //"-Yconst-opt", 
+  //"-Ybackend:GenBCode",
+  //"closurify:delegating",
   "-language:implicitConversions",
   "-language:higherKinds",
   "-language:reflectiveCalls",
@@ -61,8 +63,7 @@ scalacOptions := Seq(
       "com.basho.riak" % "riak-client" % "2.0.0.RC1",
       "org.apache.commons" % "commons-pool2" % "2.2",
       "org.slf4j" % "slf4j-api" % "1.7.7",
-      //"ch.qos.logback" % "logback-classic" % "1.1.2",
-      "org.specs2" % "specs2_2.11" % "2.4.1" % "test"
+      "org.specs2" %% "specs2" % "2.4" % "test"
       )
     }
 

--- a/src/main/scala/com/stackmob/scaliak/PBStreamingClient.scala
+++ b/src/main/scala/com/stackmob/scaliak/PBStreamingClient.scala
@@ -55,7 +55,7 @@ class PBStreamingClient(hosts: List[String], port: Int) extends RawClientWithStr
   }
 
   def ping(): Try[Void] = cluster flatMap (_.execute(new PingOperation()))
-
+  
   def listBuckets(bucketType: String = Namespace.DEFAULT_BUCKET_TYPE): Try[List[String]] = {
     cluster flatMap ({ x: RiakCluster =>
       {
@@ -78,6 +78,8 @@ class PBStreamingClient(hosts: List[String], port: Int) extends RawClientWithStr
       case Failure(t) => Failure(t)
     }
   }
+  
+  def listKeys(liop: ListKeysOperation): Try[ListKeysOperation.Response] = cluster flatMap (_.execute(liop))
 
   def fetch(foop: FetchOperation): Try[FetchOperation.Response] = cluster flatMap (_.execute(foop))
 

--- a/src/main/scala/com/stackmob/scaliak/RawClientWithStreaming.scala
+++ b/src/main/scala/com/stackmob/scaliak/RawClientWithStreaming.scala
@@ -31,7 +31,9 @@ import scala.collection.JavaConverters._
 trait RawClientWithStreaming {
 
   def ping(): Try[Void]
-
+  
+  def listKeys(liop: ListKeysOperation): Try[ListKeysOperation.Response]
+  
   def listBuckets(bucketType: String = Namespace.DEFAULT_BUCKET_TYPE): Try[List[String]]
 
   def fetchBucket(f: FetchBucketPropsOperation): Try[BucketProperties]

--- a/src/main/scala/com/stackmob/scaliak/Scaliak.scala
+++ b/src/main/scala/com/stackmob/scaliak/Scaliak.scala
@@ -16,17 +16,40 @@
 
 package com.stackmob.scaliak
 
-import scala.collection.immutable.List
-import com.basho.riak.client.core.RiakNode
+import com.stackmob.scaliak._
+import com.basho.riak.client.core.{ RiakCluster, RiakNode }
+import scala.util.{ Try, Success, Failure }
+import scala.collection.JavaConverters._
 
 object Scaliak {
 
-  def clientPool(hosts: List[String], port: Int = RiakNode.Builder.DEFAULT_REMOTE_PORT): ScaliakClientPool = {
-    new ScaliakPbClientPool(hosts, port)
+  private lazy val min_active_connections = 10
+
+  val mkCluster: LiftCluster = { p: Tuple2[List[String], Int] =>    {
+      val nodes = Try({
+        RiakNode.Builder.buildNodes(
+          (new RiakNode.Builder()
+            withRemotePort (p._2)
+            withMinConnections (min_active_connections)), new java.util.LinkedList(p._1.asJava))
+      })
+
+      val cluster: MaybeCluster = for {
+        suc_nodes <- nodes
+        suc_clust <- Try(new RiakCluster.Builder(suc_nodes).build())
+      } yield {
+        suc_clust.start
+        suc_clust
+      }
+      cluster
+    }
   }
 
+  val mkPBPool: MaybeCluster => ScaliakPbClientPool = { p: MaybeCluster => new ScaliakPbClientPool(p) }
+
+  def clientPool(hosts: List[String], port: Int = RiakNode.Builder.DEFAULT_REMOTE_PORT) = mkPBPool(mkCluster(Tuple2[List[String], Int](hosts, port)))
+
   def client(hosts: List[String], port: Int = RiakNode.Builder.DEFAULT_REMOTE_PORT): ScaliakClient = {
-    val rawClient = new PBStreamingClient(hosts, port)
+    val rawClient = new PBStreamingClient(mkCluster(Tuple2[List[String], Int](hosts, port)))
     new ScaliakClient(rawClient)
   }
 

--- a/src/main/scala/com/stackmob/scaliak/package.scala
+++ b/src/main/scala/com/stackmob/scaliak/package.scala
@@ -18,9 +18,14 @@ package com.stackmob
 
 import java.util.Date
 import com.basho.riak.client.api.cap.VClock
+import scala.util.Try
+import com.basho.riak.client.core.RiakCluster
 
 package object scaliak {
-
+  
+  type LiftCluster = (Tuple2[List[String],Int] => MaybeCluster)
+  type MaybeCluster = Try[RiakCluster] 
+  
   implicit def boolToAllowSiblingsArg(b: Boolean): AllowSiblingsArgument = AllowSiblingsArgument(Option(b))
   implicit def boolToLastWriteWinsArg(b: Boolean): LastWriteWinsArgument = LastWriteWinsArgument(Option(b))
   implicit def intToNValArg(i: Int): NValArgument = NValArgument(Option(i))

--- a/src/test/scala/com/stackmob/scaliak/tests/DeleteSpecs.scala
+++ b/src/test/scala/com/stackmob/scaliak/tests/DeleteSpecs.scala
@@ -68,12 +68,10 @@ class DeleteSpecs extends RiakWithBucketSpecs {
   val dummyWriteVal = "dummy"
   val dummyDomainConverter = ScaliakConverter.newConverter[DummyDomainObject](
     o => (new DummyDomainObject(o.key)).successNel[Throwable],
-    o => WriteObject(o.someField, dummyWriteVal.getBytes),
-    o => o.someField)
+    o => WriteObject(o.someField, dummyWriteVal.getBytes))
   val mutationValueAddition = "abc"
   val dummyDomainMutation = ScaliakMutation.newMutation[DummyDomainObject] {
-    (mbOld, newObj) =>
-      {
+    (mbOld, newObj) =>      {
         new DummyDomainObject(newObj.someField + mutationValueAddition)
       }
   }

--- a/src/test/scala/com/stackmob/scaliak/tests/PingAndListBucketsSpecs.scala
+++ b/src/test/scala/com/stackmob/scaliak/tests/PingAndListBucketsSpecs.scala
@@ -82,6 +82,8 @@ class PingAndListBucketsSpecs extends RiakSpecs {
       result must beSome.which { _.contains("test_bucket") }
     }
   }
+  
+  
 
   object charSet {
     val cdata1 = Some("""<meta http-equiv="content-type" content="text/html; charset=UTF-8">""")

--- a/src/test/scala/com/stackmob/scaliak/tests/StoreSpecs.scala
+++ b/src/test/scala/com/stackmob/scaliak/tests/StoreSpecs.scala
@@ -68,8 +68,7 @@ class StoreSpecs extends RiakWithBucketSpecs {
     o => (new DummyDomainObject(o.key)).successNel[Throwable],
     o => {
       WriteObject(o.someField, dummyWriteVal.getBytes)
-    },
-    o => o.someField)
+    })
 
   val mutationValueAddition = "abc"
 


### PR DESCRIPTION
The riak2.0 driver uses java Future to perform operations. There are various changes in the API. Read this blog entry. 

This fix moves `scalaz to 7.1`, and complies with `scala 2.11` as well. 
`mockito` is removed as the riak2.0 driver uses a builder approach to create stuff and the classes aren't exposed. 
